### PR TITLE
Deploy site to gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,10 @@
-on: [push]
-
+on:
+  push:
+    branches:
+      - deploy_to_github_pages
+      # - main
 jobs:
-  run-tests:
+  deploy:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -13,7 +16,8 @@ jobs:
           path: ~/.npm
           key: npm-${{ hashFiles('package-lock.json') }}
       - run: npm ci
-      - run: npm run prettier:check
-      - run: npm run typecheck
-      - run: npm run lint
       - run: npm run deploy
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./out

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "deploy:development": "npm run build && npm run export",
+    "deploy": "npm run build && npm run export",
     "dev": "next dev",
     "export": "next export",
     "lint": "next lint",


### PR DESCRIPTION
## 😩 失敗

- https://kjirou.github.io/taralians-language-translation-site/ 
- サブディレクトリとして配信されるんだった
- とりあえずは外部ファイルのURLがルート相対からになっているので取得できない
- 対策案
  - A) next export 時にサブディレクトリを考慮するよう調整する
    - できそうだけど調べてない
    - サブディレクトリがダサい感じのは残る
  - B) GitHub Pages 側の設定で `<sitename>.kjirou.github.io` みたいなことできる？
    - できなさそう https://docs.github.com/ja/pages/getting-started-with-github-pages/about-github-pages
  - C) Netlify にする
    - いっそこれでいいかなぁ